### PR TITLE
chore: release v0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "daktilo"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daktilo"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 description = "Turn your keyboard into a typewriter! 📇"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `daktilo`: 0.1.0-alpha.0 -> 0.1.0-alpha.1

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).