### PR TITLE
feat(playback): allow specifying multiple presets at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ To use a preset:
 daktilo --preset musicbox
 ```
 
+You can also use multiple presets at the same time:
+
+```sh
+# orchestra
+daktilo -p default -p musicbox -p drumkit
+```
+
 To use a different output device:
 
 ```sh

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,8 +35,10 @@ pub struct Args {
     #[arg(short, long, env)]
     pub verbose: bool,
     /// Sets the name of the sound preset to use.
-    #[arg(short, long, env)]
-    pub preset: Option<String>,
+    ///
+    /// Can be specified multiple times to play multiple presets at once.
+    #[arg(short, long, env, num_args(0..))]
+    pub preset: Vec<String>,
     /// Lists the available presets.
     #[arg(short, long, aliases = vec!["ls", "list"])]
     pub list_presets: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,20 @@ async fn main() -> Result<()> {
             })?;
         return Ok(());
     }
-    let preset_name = args.preset.unwrap_or_else(|| String::from("default"));
-    let preset = config.select_preset(&preset_name)?;
-    match daktilo::run(preset, args.device).await {
+
+    let presets = if args.preset.is_empty() {
+        tracing::debug!("No preset specified, using the default preset.");
+        vec![String::from("default")]
+    } else {
+        args.preset
+    };
+
+    let presets = presets
+        .iter()
+        .map(|name| config.select_preset(name))
+        .collect::<Result<Vec<_>>>()?;
+
+    match daktilo::run(presets, args.device).await {
         Ok(_) => process::exit(0),
         Err(e) => {
             tracing::error!("error occurred: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,16 +56,14 @@ async fn main() -> Result<()> {
     }
 
     let presets = if args.preset.is_empty() {
-        tracing::debug!("No preset specified, using the default preset.");
+        tracing::warn!("No preset specified, using the default preset.");
         vec![String::from("default")]
     } else {
         args.preset
-    };
-
-    let presets = presets
-        .iter()
-        .map(|name| config.select_preset(name))
-        .collect::<Result<Vec<_>>>()?;
+    }
+    .iter()
+    .map(|name| config.select_preset(name))
+    .collect::<Result<Vec<_>>>()?;
 
     match daktilo::run(presets, args.device).await {
         Ok(_) => process::exit(0),


### PR DESCRIPTION
<!--- Thank you for contributing to daktilo! -->

## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Allow to specify `preset` multiple times. All presets are played at the same time.

Closes #35

## How has this been tested? (if applicable)

<!-- Please describe any tests that you ran to verify your changes. -->
- `daktilo` uses the default profile
- `daktilo -p musicbox` uses musicbox profile only
- `daktilo -p default -p musicbox -p drumkit` is an orchestra
