### PR TITLE
feat(playback): add random variation on each keypress (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ As shown above, `sound_preset` consists of 2 entries:
 - `name`: The name of the preset. It will be used in conjunction with `--preset` flag. e.g. `--preset custom`
 - `key_config`: An array of key press/release events for assigning audio files to the specified keys. It can also be used to control the volume etc.
 - `disabled_keys`: An array of keys that will not be used for playback.
-- `variation`: Variate the sound on each event for `KeyConfig`'s that do not specify variations[\*](#sound-variation)
+- `variation`: Variate the sound on each event for `key_config`s that do not specify variations[\*](#sound-variation)
 
 <details>
   <summary>Click for the <a href="https://docs.rs/rdev/latest/rdev/enum.Key.html">list of available keys</a>.</summary>
@@ -336,8 +336,8 @@ Values are in percent, where the first value determines the maximum increase and
 - If command line arguments or environment variables are set configurations made in the presets are overridden.
   - Values need to be separated by a ",".
   - If only one value is supplied it is used for both increase and decrease
-- If a `KeyConfig` is set the preset values are overridden.
-- The configuration on a preset applies to all `KeyConfig`'s that do not have any values set.
+- If a `key_config` is set the preset values are overridden.
+- The configuration on a preset applies to all `key_config`'s that do not have any values set.
 
 ## Similar Projects
 

--- a/README.md
+++ b/README.md
@@ -181,15 +181,17 @@ daktilo [OPTIONS]
 **Options**:
 
 ```sh
--v, --verbose               Enables verbose logging [env: VERBOSE=]
--p, --preset [<PRESET>...]  Sets the name of the sound preset to use [env: PRESET=]
--l, --list-presets          Lists the available presets
-    --list-devices          Lists the available output devices
--d, --device <DEVICE>       Sets the device for playback [env: DAKTILO_DEVICE=]
--c, --config <PATH>         Sets the configuration file [env: DAKTILO_CONFIG=]
--i, --init                  Writes the default configuration file
--h, --help                  Print help (see more with '--help')
--V, --version               Print version
+-v, --verbose                                    Enables verbose logging [env: VERBOSE=]
+-p, --preset [<PRESET>...]                       Sets the name of the sound preset to use [env: PRESET=]
+-l, --list-presets                               Lists the available presets
+    --list-devices                               Lists the available output devices
+-d, --device <DEVICE>                            Sets the device for playback [env: DAKTILO_DEVICE=]
+-c, --config <PATH>                              Sets the configuration file [env: DAKTILO_CONFIG=]
+-i, --init                                       Writes the default configuration file
+    --variate-volume <PERCENT_UP[,PERCENT_DOWN]> Variate volume +/- in percent [env: DAKTILO_VOLUME=]
+    --variate-tempo <PERCENT_UP[,PERCENT_DOWN]>  Variate tempo +/- in percent [env: DAKTILO_TEMPO=]
+-h, --help                                       Print help (see more with '--help')
+-V, --version                                    Print version
 ```
 
 ## Configuration
@@ -235,6 +237,7 @@ key_config = []
 name = "another_custom"
 key_config = []
 disabled_keys = []
+variation = { volume: [0.1, 0.1], tempo: [0.05, 0.05] }
 ```
 
 As shown above, `sound_preset` consists of 2 entries:
@@ -242,6 +245,7 @@ As shown above, `sound_preset` consists of 2 entries:
 - `name`: The name of the preset. It will be used in conjunction with `--preset` flag. e.g. `--preset custom`
 - `key_config`: An array of key press/release events for assigning audio files to the specified keys. It can also be used to control the volume etc.
 - `disabled_keys`: An array of keys that will not be used for playback.
+- `variation`: Variate the sound on each event for `KeyConfig`'s that do not specify variations[*](#sound-variation)
 
 <details>
   <summary>Click for the <a href="https://docs.rs/rdev/latest/rdev/enum.Key.html">list of available keys</a>.</summary>
@@ -263,6 +267,7 @@ key_config = [
 - `files`: An array of files.
   - `path`: The absolute path of the file. If the file is embedded in the binary (i.e. if it is inside `sounds/` directory) then it is the name of the file without full path.
   - `volume`: The volume of the sound. The value 1.0 is the "normal" volume (unfiltered input). Any value other than 1.0 will multiply each sample by this value.
+- `variation`: Variate the sound on each `event`[*](#sound-variation)
 
 If you have defined multiple files for a key event, you can also specify a strategy for how to play them:
 
@@ -308,12 +313,23 @@ key_config = [
     { path = "cat.mp3" },
     { path = "dog.mp3" },
     { path = "bird.mp3" },
-  ], strategy = "random" },
+  ], strategy = "random", variation = { volume: [0.1, 0.1], tempo: [0.05, 0.05] } },
 ]
 
 # Disabled keys that won't trigger any sound events
 disabled_keys = ["CapsLock", "NumLock"]
 ```
+### Sound Variation
+
+To make the keyboard sounds more varied it is possible to variate both volume and playback speed (the later also varies the pitch).
+
+Values are in percent, where the first value determines the maximum increase and the second the maximum decrease. The actual value is determined randomly on each keypress.
+
+- If cli or environment variables are set configurations made in the presets are overridden.
+  - Values need to be separated by a `,`
+  - If only one value is supplied it is used for both increase and decrease
+- If a `KeyConfig` is set the preset values are overridden.
+- The configuration on a preset applies to all `KeyConfig`'s that do not have any values set.
 
 ## Similar Projects
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Now you can recreate this moment without the actual need for a physical typewrit
 - [Usage](#usage)
 - [Configuration](#configuration)
   - [Adding custom presets](#adding-custom-presets)
+  - [Sound Variation](#sound-variation)
 - [Similar Projects](#similar-projects)
 - [Acknowledgements](#acknowledgements)
 - [Donations](#donations)
@@ -92,6 +93,12 @@ daktilo --device pipewire
 ```
 
 Also, you can use `--list-devices` to list the available output devices.
+
+To variate the sounds and have a more realistic typewriter experience:
+
+```sh
+daktilo --variate-tempo 0.9,0.4 --variate-volume 0.1,0.5
+```
 
 ## Supported Platforms
 
@@ -245,7 +252,7 @@ As shown above, `sound_preset` consists of 2 entries:
 - `name`: The name of the preset. It will be used in conjunction with `--preset` flag. e.g. `--preset custom`
 - `key_config`: An array of key press/release events for assigning audio files to the specified keys. It can also be used to control the volume etc.
 - `disabled_keys`: An array of keys that will not be used for playback.
-- `variation`: Variate the sound on each event for `KeyConfig`'s that do not specify variations[*](#sound-variation)
+- `variation`: Variate the sound on each event for `KeyConfig`'s that do not specify variations[\*](#sound-variation)
 
 <details>
   <summary>Click for the <a href="https://docs.rs/rdev/latest/rdev/enum.Key.html">list of available keys</a>.</summary>
@@ -267,7 +274,7 @@ key_config = [
 - `files`: An array of files.
   - `path`: The absolute path of the file. If the file is embedded in the binary (i.e. if it is inside `sounds/` directory) then it is the name of the file without full path.
   - `volume`: The volume of the sound. The value 1.0 is the "normal" volume (unfiltered input). Any value other than 1.0 will multiply each sample by this value.
-- `variation`: Variate the sound on each `event`[*](#sound-variation)
+- `variation`: Variate the sound on each `event`[\*](#sound-variation)
 
 If you have defined multiple files for a key event, you can also specify a strategy for how to play them:
 
@@ -319,14 +326,15 @@ key_config = [
 # Disabled keys that won't trigger any sound events
 disabled_keys = ["CapsLock", "NumLock"]
 ```
+
 ### Sound Variation
 
 To make the keyboard sounds more varied it is possible to variate both volume and playback speed (the later also varies the pitch).
 
 Values are in percent, where the first value determines the maximum increase and the second the maximum decrease. The actual value is determined randomly on each keypress.
 
-- If cli or environment variables are set configurations made in the presets are overridden.
-  - Values need to be separated by a `,`
+- If command line arguments or environment variables are set configurations made in the presets are overridden.
+  - Values need to be separated by a ",".
   - If only one value is supplied it is used for both increase and decrease
 - If a `KeyConfig` is set the preset values are overridden.
 - The configuration on a preset applies to all `KeyConfig`'s that do not have any values set.

--- a/config/daktilo.toml
+++ b/config/daktilo.toml
@@ -17,10 +17,10 @@ key_config = [
   { event = "press", keys = "Return", files = [
     { path = "ding.mp3", volume = 1.0 },
   ] },
-  { event = "press", keys = ".*", files = [
+  { event = "press", keys = ".*", variation = { volume = [0.2, 0.2], tempo = [0.1, 0.1] }, files = [
     { path = "keydown.mp3", volume = 1.0 },
   ] },
-  { event = "release", keys = ".*", files = [
+  { event = "release", keys = ".*", variation = { volume = [0.2, 0.2], tempo = [0.1, 0.1] }, files = [
     { path = "keyup.mp3", volume = 1.0 },
   ] },
 ]

--- a/config/daktilo.toml
+++ b/config/daktilo.toml
@@ -17,10 +17,10 @@ key_config = [
   { event = "press", keys = "Return", files = [
     { path = "ding.mp3", volume = 1.0 },
   ] },
-  { event = "press", keys = ".*", variation = { volume = [0.2, 0.2], tempo = [0.1, 0.1] }, files = [
+  { event = "press", keys = ".*", variation = { volume = [0.1, 0.1], tempo = [0.05, 0.05] }, files = [
     { path = "keydown.mp3", volume = 1.0 },
   ] },
-  { event = "release", keys = ".*", variation = { volume = [0.2, 0.2], tempo = [0.1, 0.1] }, files = [
+  { event = "release", keys = ".*", variation = { volume = [0.1, 0.1], tempo = [0.05, 0.05] }, files = [
     { path = "keyup.mp3", volume = 1.0 },
   ] },
 ]

--- a/src/args.rs
+++ b/src/args.rs
@@ -64,26 +64,41 @@ pub struct Args {
 /// Variate pitch/volume/tempo.
 #[derive(clap::Args, Default, Debug)]
 pub struct SoundVariationArgs {
-    /// Variate pitch +/- in percent.
-    /// Overrides preset configuration.
-    #[arg(long, env = "DAKTILO_PITCH", value_name = "PERCENT")]
-    pub variate_pitch: Option<f32>,
     /// Variate volume +/- in percent.
-    /// Overrides preset configuration.
-    #[arg(long, env = "DAKTILO_VOLUME", value_name = "PERCENT")]
-    pub variate_volume: Option<f32>,
+    #[arg(
+        long,
+        env = "DAKTILO_VOLUME",
+        value_name = "PERCENT_UP[,PERCENT_DOWN]",
+        value_delimiter = ',',
+        num_args(1..2)
+    )]
+    pub variate_volume: Option<Vec<f32>>,
     /// Variate tempo +/- in percent.
-    /// Overrides preset configuration.
-    #[arg(long, env = "DAKTILO_TEMPO", value_name = "PERCENT")]
-    pub variate_tempo: Option<f32>,
+    #[arg(
+        long,
+        env = "DAKTILO_TEMPO",
+        value_name = "PERCENT_UP[,PERCENT_DOWN]",
+        value_delimiter = ',',
+        num_args(1..2)
+    )]
+    pub variate_tempo: Option<Vec<f32>>,
 }
 
-impl Into<SoundVariation> for SoundVariationArgs {
-    fn into(self) -> SoundVariation {
-        SoundVariation {
-            pitch: self.variate_pitch.map(|pitch| (pitch, pitch)),
-            volume: self.variate_volume.map(|volume| (volume, volume)),
-            tempo: self.variate_tempo.map(|tempo| (tempo, tempo)),
+impl From<SoundVariationArgs> for SoundVariation {
+    fn from(args: SoundVariationArgs) -> Self {
+        Self {
+            volume: args.variate_volume.map(|v| {
+                (
+                    v.first().cloned().unwrap_or(1.0),
+                    v.get(1).or(v.first()).cloned().unwrap_or(1.0),
+                )
+            }),
+            tempo: args.variate_tempo.map(|t| {
+                (
+                    t.first().cloned().unwrap_or(1.0),
+                    t.get(1).or(t.first()).cloned().unwrap_or(1.0),
+                )
+            }),
         }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
+use crate::config::SoundVariation;
+
 /// Typewriter ASCII banner.
 pub const BANNER: &str = r#"
       .-------.
@@ -52,6 +54,36 @@ pub struct Args {
     /// Writes the default configuration file.
     #[arg(short, long)]
     pub init: bool,
+    /// Variate pitch/volume/tempo.
+    #[command(flatten)]
+    pub sound_variation_args: Option<SoundVariationArgs>,
+}
+
+/// Variate pitch/volume/tempo.
+#[derive(clap::Args, Default, Debug)]
+pub struct SoundVariationArgs {
+    /// Variate pitch +/- in percent.
+    /// Overrides preset configuration.
+    #[arg(long, env = "DAKTILO_PITCH", value_name = "PERCENT")]
+    pub variate_pitch: Option<f32>,
+    /// Variate volume +/- in percent.
+    /// Overrides preset configuration.
+    #[arg(long, env = "DAKTILO_VOLUME", value_name = "PERCENT")]
+    pub variate_volume: Option<f32>,
+    /// Variate tempo +/- in percent.
+    /// Overrides preset configuration.
+    #[arg(long, env = "DAKTILO_TEMPO", value_name = "PERCENT")]
+    pub variate_tempo: Option<f32>,
+}
+
+impl Into<SoundVariation> for SoundVariationArgs {
+    fn into(self) -> SoundVariation {
+        SoundVariation {
+            pitch: self.variate_pitch.map(|pitch| (pitch, pitch)),
+            volume: self.variate_volume.map(|volume| (volume, volume)),
+            tempo: self.variate_tempo.map(|tempo| (tempo, tempo)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,8 +83,8 @@ impl Config {
                         }],
                         strategy: None,
                         variation: Some(SoundVariation {
-                            pitch: Some((0.5, 0.5)),
-                            ..Default::default()
+                            volume: Some((0.1, 0.1)),
+                            tempo: Some((0.075, 0.075)),
                         }),
                     },
                 ],
@@ -202,8 +202,6 @@ pub enum PlaybackStrategy {
 pub struct SoundVariation {
     /// Volume +/- in percent.
     pub volume: Option<(f32, f32)>,
-    /// Pitch +/- in percent.
-    pub pitch: Option<(f32, f32)>,
     /// Tempo +/- in percent.
     pub tempo: Option<(f32, f32)>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,7 @@ impl Config {
                             },
                         ],
                         strategy: Some(PlaybackStrategy::Random),
+                        variation: None,
                     },
                     KeyConfig {
                         event: KeyEvent::KeyPress,
@@ -81,9 +82,14 @@ impl Config {
                             volume: None,
                         }],
                         strategy: None,
+                        variation: Some(SoundVariation {
+                            pitch: Some((0.5, 0.5)),
+                            ..Default::default()
+                        }),
                     },
                 ],
                 disabled_keys: None,
+                variation: None,
             });
         }
         self.sound_presets
@@ -103,6 +109,8 @@ pub struct SoundPreset {
     pub key_config: Vec<KeyConfig>,
     /// List of disabled keys.
     pub disabled_keys: Option<Vec<Key>>,
+    /// Configure sound variations.
+    pub variation: Option<SoundVariation>,
 }
 
 impl fmt::Display for SoundPreset {
@@ -153,6 +161,8 @@ pub struct KeyConfig {
     pub files: Vec<AudioFile>,
     /// Playback strategy.
     pub strategy: Option<PlaybackStrategy>,
+    /// Sound variations. Overrides the preset sound variations.
+    pub variation: Option<SoundVariation>,
 }
 
 /// Key event type.
@@ -184,6 +194,18 @@ pub enum PlaybackStrategy {
     Random,
     /// Play sequentially.
     Sequential,
+}
+
+/// Sound variation configuration.
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SoundVariation {
+    /// Volume +/- in percent.
+    pub volume: Option<(f32, f32)>,
+    /// Pitch +/- in percent.
+    pub pitch: Option<(f32, f32)>,
+    /// Tempo +/- in percent.
+    pub tempo: Option<(f32, f32)>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,17 @@ pub mod app;
 pub mod config;
 
 use app::App;
-use config::SoundPreset;
+use config::{SoundPreset, SoundVariation};
 use error::Result;
 use rdev::listen;
 use std::thread;
 
 /// Starts the typewriter.
-pub async fn run(sound_preset: SoundPreset, device: Option<String>) -> Result<()> {
+pub async fn run(
+    sound_preset: SoundPreset,
+    variation: Option<SoundVariation>,
+    device: Option<String>,
+) -> Result<()> {
     // Create a listener for the keyboard events.
     let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
     thread::spawn(move || {
@@ -41,7 +45,7 @@ pub async fn run(sound_preset: SoundPreset, device: Option<String>) -> Result<()
 
     // Create the application state.
     tracing::debug!("{:#?}", sound_preset);
-    let mut app = App::init(sound_preset, device)?;
+    let mut app = App::init(sound_preset, variation, device)?;
 
     // Handle events.
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,13 @@ async fn main() -> Result<()> {
     }
     let preset_name = args.preset.unwrap_or_else(|| String::from("default"));
     let preset = config.select_preset(&preset_name)?;
-    match daktilo::run(preset, args.device).await {
+    match daktilo::run(
+        preset,
+        args.sound_variation_args.map(|v| v.into()),
+        args.device,
+    )
+    .await
+    {
         Ok(_) => process::exit(0),
         Err(e) => {
             tracing::error!("error occurred: {e}");


### PR DESCRIPTION
<!--- Thank you for contributing to daktilo! -->

## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Adds the possibility of random variation for each keypress
- [x]  Volume
- [x]  Tempo / Pitch

I added some values to the default preset. Maybe play around with those to find sensible defaults. :heavy_check_mark: 

Closes #24 

### Configuration
I added configuration possibilities in 3 places:

1. CLI Arguments. These will override all settings defined in Presets.
2. `KeyConfig` in Preset. These will override settings defined in the parent Preset.
3. Preset. Will apply to all `KeyConfig`s that do not provide variation.

~~Currently the cli only accepts one value, that is used for both changes up and down, while the config file takes separate values. I am looking into a convenient way to allow both for the cli as well.~~

The cli accepts (up to) two comma separated values. If only one is defined it is used for both.

## How has this been tested? (if applicable)

<!-- Please describe any tests that you ran to verify your changes. -->
- Set high values in config and use :ear: 
- Set high values in cli and use :ear: 
- Watch trace logs.