### PR TITLE
feat(config): add option to disable easter eggs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ Also, you can use `--list-devices` to list the available output devices.
 <details>
   <summary>Spoiler warning</summary>
 
-  There are easter eggs. If that is something you do not like you can disable them either via the config file option `no_surprises = true` or using the cli flag:
+There are easter eggs. If that is something you do not like you can disable them either via the config file option `no_surprises = true` or using the command-line flag:
 
-  ```sh
-  daktilo --no-surprises
-  ```
+```sh
+daktilo --no-surprises
+```
+
 </details>
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ daktilo --device pipewire
 
 Also, you can use `--list-devices` to list the available output devices.
 
+<details>
+  <summary>Spoiler warning</summary>
+
+  There are easter eggs. If that is something you do not like you can disable them either via the config file option `no_surprises = true` or using the cli flag:
+
+  ```sh
+  daktilo --no-surprises
+  ```
+</details>
+
 ## Supported Platforms
 
 - [x] Linux

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,9 @@ pub struct Args {
     /// Writes the default configuration file.
     #[arg(short, long)]
     pub init: bool,
+    /// Disables the easter eggs.
+    #[arg(long, hide = true)]
+    pub no_surprises: bool,
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,9 @@ pub struct Config {
     /// Sound presets.
     #[serde(rename = "sound_preset")]
     pub sound_presets: Vec<SoundPreset>,
+    /// Disable the easter eggs.
+    #[serde(rename = "no_surprises", default)]
+    pub disable_easter_eggs: bool,
 }
 
 impl Config {
@@ -54,7 +57,7 @@ impl Config {
 
     /// Returns a preset by its name if it exists.
     pub fn select_preset(&self, name: &str) -> Result<SoundPreset> {
-        if fastrand::usize(0..1000) == 42 || name == "ak47" {
+        if !self.disable_easter_eggs && fastrand::usize(0..1000) == 42 || name == "ak47" {
             return Ok(SoundPreset {
                 name: String::new(),
                 key_config: vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,19 @@ async fn main() -> Result<()> {
         return Ok(());
     }
     let config_path = args.config.or(Config::get_default_location());
-    let config = if config_path.as_ref().is_some_and(|v| v.exists()) {
+    let mut config = if config_path.as_ref().is_some_and(|v| v.exists()) {
         // unwrap is checked above.
         Config::parse(&config_path.unwrap())?
     } else {
         tracing::warn!("Using the default configuration (run with `--init` to save it to a file).");
         EmbeddedConfig::parse()?
     };
+
+    if args.no_surprises {
+        tracing::debug!("I bet you're fun at parties.");
+        config.disable_easter_eggs = true;
+    }
+
     tracing::debug!("{:#?}", config);
 
     // Start the typewriter.


### PR DESCRIPTION
<!--- Thank you for contributing to daktilo! -->

## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Add `no_surprises` to config file and `--no-surprises` to cli.

The `ak` preset can still be activated by using the pseset name. Maybe add an easter egg for selecting that preset with easter eggs disabled :thinking: 

Closes #45 

## How has this been tested? (if applicable)

<!-- Please describe any tests that you ran to verify your changes. -->
- Inverted the condition on the easter egg and tested with / without disabled.
